### PR TITLE
use relative file path for file dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "win-wifi",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Scan, connect, and disconnect wifi network in Windows 10.",
   "homepage": "https://github.com/obermillerk/win-wifi",
   "bugs": "https://github.com/obermillerk/win-wifi/issues",

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "windows.security.credentials"
   ],
   "dependencies": {
-    "deasync": "file:deasync-0.1.10-custom.tgz",
-    "windows.devices.enumeration": "file:windows.devices.enumeration-0.1.0.tgz",
-    "windows.devices.wifi": "file:windows.devices.wifi-0.1.0.tgz",
-    "windows.networking.connectivity": "file:windows.networking.connectivity-0.1.0.tgz",
-    "windows.security.credentials": "file:windows.security.credentials-0.1.0.tgz"
+    "deasync": "file:./deasync-0.1.10-custom.tgz",
+    "windows.devices.enumeration": "file:./windows.devices.enumeration-0.1.0.tgz",
+    "windows.devices.wifi": "file:./windows.devices.wifi-0.1.0.tgz",
+    "windows.networking.connectivity": "file:./windows.networking.connectivity-0.1.0.tgz",
+    "windows.security.credentials": "file:./windows.security.credentials-0.1.0.tgz"
   }
 }


### PR DESCRIPTION
This seems to fix the following error when installing with Yarn:
```
[1/4] Resolving packages...
error Couldn't find package "windows.devices.wifi@*" required by "win-wifi" on the "npm" registry.
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```